### PR TITLE
Fix: Remove useless quotes (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 👋 HTML-Classes-Obfuscator 🔒
 
-> CLI that obfuscate HTML classes:
+> CLI tool that obfuscates HTML classes:
 >
 > _Normal HTML file_ :
 
@@ -20,7 +20,7 @@
 
 ## 🚀 Usage
 
-Using by command line
+Via command line...
 
 ```bash
 git clone git@github.com:xandermann/html-classes-obfuscator.git
@@ -30,7 +30,7 @@ cp html-classes-obfuscator/html_classes_obfuscator/html_classes_obfuscator.py ./
 python3 html_classes_obfuscator.py --htmlpath="**/*.html" --csspath="**/*.css" --jspath="**/*.js"
 ```
 
-Or using in python script
+...Or via a python script
 
 ```bash
 # https://pypi.org/project/html-classes-obfuscator/

--- a/html_classes_obfuscator/html_classes_obfuscator.py
+++ b/html_classes_obfuscator/html_classes_obfuscator.py
@@ -43,12 +43,10 @@ def html_classes_obfuscator(htmlfiles = [], cssfiles = [], jsfiles = [], generat
             # --------------------------------------------------
 
             for i, classes in enumerate(classes_groups):
-                print(i, classes)
-                print(obfuscate_classes_groups[i], len(obfuscate_classes_groups[i]))
 
                 old_no_quote = "class=" + classes_groups[i]
                 old_with_quote = 'class="' + classes_groups[i] + '"'
-                if len(obfuscate_classes_groups[i]) > 0:
+                if len(obfuscate_classes_groups[i].split()) > 1:
                     replace_by = 'class="' + obfuscate_classes_groups[i] + '"'
                 else:
                     replace_by = 'class=' + obfuscate_classes_groups[i] + ''

--- a/html_classes_obfuscator/html_classes_obfuscator.py
+++ b/html_classes_obfuscator/html_classes_obfuscator.py
@@ -43,10 +43,15 @@ def html_classes_obfuscator(htmlfiles = [], cssfiles = [], jsfiles = [], generat
             # --------------------------------------------------
 
             for i, classes in enumerate(classes_groups):
+                print(i, classes)
+                print(obfuscate_classes_groups[i], len(obfuscate_classes_groups[i]))
 
                 old_no_quote = "class=" + classes_groups[i]
                 old_with_quote = 'class="' + classes_groups[i] + '"'
-                replace_by = 'class=' + obfuscate_classes_groups[i] + ''
+                if len(obfuscate_classes_groups[i]) > 0:
+                    replace_by = 'class="' + obfuscate_classes_groups[i] + '"'
+                else:
+                    replace_by = 'class=' + obfuscate_classes_groups[i] + ''
 
                 # Replace like : class=navbar-item by class="{{ obfuscate_classes_groups }}"
                 # Or replace like : class="navbar p-5" (with quote this time)

--- a/html_classes_obfuscator/html_classes_obfuscator.py
+++ b/html_classes_obfuscator/html_classes_obfuscator.py
@@ -46,14 +46,12 @@ def html_classes_obfuscator(htmlfiles = [], cssfiles = [], jsfiles = [], generat
 
                 old_no_quote = "class=" + classes_groups[i]
                 old_with_quote = 'class="' + classes_groups[i] + '"'
-                replace_by = 'class="' + obfuscate_classes_groups[i] + '"'
+                replace_by = 'class=' + obfuscate_classes_groups[i] + ''
 
                 # Replace like : class=navbar-item by class="{{ obfuscate_classes_groups }}"
                 # Or replace like : class="navbar p-5" (with quote this time)
                 file_content = file_content.replace(old_no_quote, replace_by)
                 file_content = file_content.replace(old_with_quote, replace_by)
-
-                # TODO : remove the quotes if not needed in "replaced_by"
 
             f.seek(0)
             f.write(file_content)


### PR DESCRIPTION
Remove useless quotes in obfuscated class names.

```html
<!-- Before -->
<div class="inzPuw"></div>

<!-- After -->
<div class=inzPuw></div>
```